### PR TITLE
Deploy NFT contract when running `fresh dev`

### DIFF
--- a/packages/freshmint/commands/deploy.ts
+++ b/packages/freshmint/commands/deploy.ts
@@ -1,56 +1,20 @@
-import * as fs from 'fs/promises';
 import { Command } from 'commander';
 import ora from 'ora';
 import chalk from 'chalk';
-import { CollectionMetadata } from '@freshmint/core';
-
-// @ts-ignore
-import * as mime from 'mime-types';
 
 import { FlowGateway, FlowNetwork } from '../flow';
 import { loadConfig } from '../config';
-import { FlowJSONConfig } from '../flow/config';
-import { FreshmintError } from '../errors';
+import { deployNFTContract } from '../deploy';
 
 export default new Command('deploy')
   .description('deploy your NFT contract')
   .option('-n, --network <network>', "Network to deploy to. Either 'emulator', 'testnet' or 'mainnet'", 'emulator')
   .action(deploy);
 
-const flowJSONConfigPath = 'flow.json';
-
 async function deploy({ network }: { network: FlowNetwork }) {
   const config = await loadConfig();
 
   const flow = new FlowGateway(network, config.getContractAccount(network));
-
-  const contractName = config.contract.name;
-  const flowConfig = await FlowJSONConfig.load(flowJSONConfigPath);
-
-  const contractPath = flowConfig.getContract(contractName);
-
-  if (!contractPath) {
-    throw new FreshmintError(`Contract ${contractName} is not defined in flow.json.`);
-  }
-
-  const collectionMetadata: CollectionMetadata = {
-    name: config.collection.name,
-    description: config.collection.description,
-    url: config.collection.url,
-    squareImage: {
-      url: config.collection.images.square,
-      type: mime.lookup(config.collection.images.square),
-    },
-    bannerImage: {
-      url: config.collection.images.banner,
-      type: mime.lookup(config.collection.images.banner),
-    },
-    socials: config.collection.socials,
-  };
-
-  const royalties = config.royalties[network];
-
-  const contract = await fs.readFile(contractPath, 'utf-8');
 
   const spinner = ora();
 
@@ -58,12 +22,7 @@ async function deploy({ network }: { network: FlowNetwork }) {
 
   spinner.start(`Deploying ${config.contract.name} to ${network}...`);
 
-  try {
-    await flow.deploy(contractName, contract, collectionMetadata, royalties);
-  } catch (error: any) {
-    spinner.fail('Failed to deploy:\n');
-    throw new FreshmintError(error);
-  }
+  await deployNFTContract(config, flow, network);
 
   spinner.succeed(`Success! Deployed ${chalk.cyan(config.contract.name)} to ${network}.`);
 }

--- a/packages/freshmint/commands/dev.ts
+++ b/packages/freshmint/commands/dev.ts
@@ -1,9 +1,12 @@
 import { Command } from 'commander';
 
+import { loadConfig } from '../config';
 import { runDevServer } from '../devServer';
 
 export default new Command('dev').description('start the Freshmint development server').action(dev);
 
 async function dev() {
-  await runDevServer();
+  const config = await loadConfig();
+
+  await runDevServer(config);
 }

--- a/packages/freshmint/deploy.ts
+++ b/packages/freshmint/deploy.ts
@@ -1,0 +1,44 @@
+import * as fs from 'fs/promises';
+import { CollectionMetadata } from '@freshmint/core';
+
+// @ts-ignore
+import * as mime from 'mime-types';
+
+import { FreshmintConfig } from './config';
+import { FreshmintError } from './errors';
+import { FlowGateway, FlowNetwork } from './flow';
+import { FlowJSONConfig } from './flow/config';
+
+const flowJSONConfigPath = 'flow.json';
+
+export async function deployNFTContract(config: FreshmintConfig, flow: FlowGateway, network: FlowNetwork) {
+  const contractName = config.contract.name;
+  const flowConfig = await FlowJSONConfig.load(flowJSONConfigPath);
+
+  const contractPath = flowConfig.getContract(contractName);
+
+  if (!contractPath) {
+    throw new FreshmintError(`Contract ${contractName} is not defined in flow.json.`);
+  }
+
+  const collectionMetadata: CollectionMetadata = {
+    name: config.collection.name,
+    description: config.collection.description,
+    url: config.collection.url,
+    squareImage: {
+      url: config.collection.images.square,
+      type: mime.lookup(config.collection.images.square),
+    },
+    bannerImage: {
+      url: config.collection.images.banner,
+      type: mime.lookup(config.collection.images.banner),
+    },
+    socials: config.collection.socials,
+  };
+
+  const royalties = config.royalties[network];
+
+  const contract = await fs.readFile(contractPath, 'utf-8');
+
+  await flow.deploy(contractName, contract, collectionMetadata, royalties);
+}

--- a/packages/freshmint/devServer/deploySupportingContracts.ts
+++ b/packages/freshmint/devServer/deploySupportingContracts.ts
@@ -1,6 +1,11 @@
 import { spawnProcess } from './process';
 
-export async function deployContracts() {
+// Deploy Freshmint's supporting contracts to the emulator.
+//
+// Note: this does not deploy the user's NFT contract
+// because it requires special arguments not supported by `flow deploy`.
+//
+export async function deploySupportingContracts() {
   return new Promise((resolve, reject) => {
     // TODO: capture number of contracts deployed and address
     spawnProcess('flow', ['deploy', '-o', 'json'], {

--- a/packages/freshmint/devServer/index.ts
+++ b/packages/freshmint/devServer/index.ts
@@ -2,15 +2,16 @@ import chalk from 'chalk';
 
 import { startEmulator, EmulatorTransaction } from './startEmulator';
 import { startDevWallet } from './startDevWallet';
-import { deployContracts } from './deployContracts';
-
-export type ServerReadyHandler<T> = (value: T) => void;
+import { deploySupportingContracts } from './deploySupportingContracts';
+import { deployNFTContract } from '../deploy';
+import { FreshmintConfig } from '../config';
+import { FlowGateway } from '../flow';
 
 // TODO: clean up the child process handling logic
 //
 // Ensure that the emulator and dev wallet servers are never left running
 
-export async function runDevServer() {
+export async function runDevServer(config: FreshmintConfig) {
   const emulator = await startEmulator({
     onTransaction: (tx: EmulatorTransaction) => {
       if (tx.error) {
@@ -31,7 +32,7 @@ export async function runDevServer() {
     `${chalk.green('ready')} - started emulator on 0.0.0.0:${emulator.port}, url: http://localhost:${emulator.port}`,
   );
 
-  // Disable emulator output when deploying contracts to keep console clean
+  // Disable emulator output before starting dev wallet and deploying contracts to keep console clean
   emulator.showOutput(false);
 
   const devWallet = await startDevWallet();
@@ -43,8 +44,18 @@ export async function runDevServer() {
   );
 
   try {
-    await deployContracts();
-    console.log(`${chalk.green('ready')} - project contracts deployed`);
+    // Deploy the supporting contracts to the emulator
+    await deploySupportingContracts();
+
+    console.log(`${chalk.green('ready')} - deployed Freshmint contracts to the emulator`);
+
+    const network = 'emulator';
+    const flow = new FlowGateway(network, config.getContractAccount(network));
+
+    // Deploy the user's NFT contract to the emulator
+    await deployNFTContract(config, flow, network);
+
+    console.log(`${chalk.green('ready')} - deployed ${chalk.cyan(config.contract.name)} to the emulator`);
   } catch (error) {
     console.log(`${chalk.redBright('error - failed to deploy contracts:')}\n\n${chalk.red(error)}`);
 

--- a/packages/freshmint/generate/templates/README.md
+++ b/packages/freshmint/generate/templates/README.md
@@ -14,18 +14,12 @@ This project uses the [Flow emulator](https://github.com/onflow/flow-emulator) a
 
 ### Start the development server
 
-This command launches the emulator, dev wallet and deploys all contract dependencies.
+This command launches the emulator, dev wallet and deploys all Cadence contracts.
 
 Keep it running while you build!
 
 ```sh
 fresh dev
-```
-
-### Deploy your contract
-
-```sh
-fresh deploy
 ```
 
 ### Configure NFT.Storage for IPFS


### PR DESCRIPTION
This PR updates `fresh dev` to also deploy the user's NFT contract after starting the emulator.

This is a UX improvement to prevent users from needing to run `fresh deploy` when developing locally using the emulator.