### PR TITLE
Add limit field to editions.csv

### DIFF
--- a/.changeset/sour-cougars-bathe.md
+++ b/.changeset/sour-cougars-bathe.md
@@ -1,0 +1,5 @@
+---
+'freshmint': minor
+---
+
+Add support for edition_limit field

--- a/packages/freshmint/commands/mint.ts
+++ b/packages/freshmint/commands/mint.ts
@@ -189,7 +189,7 @@ async function mintEdition(
       }
 
       editionSpinner.succeed(
-        `Successfully created ${pluralize(count, 'new edition template')} to ${chalk.cyan(config.contract.name)}.`,
+        `Successfully created ${pluralize(count, 'new edition template')} in ${chalk.cyan(config.contract.name)}.`,
       );
     },
     onStartMinting: (nftCount: number, batchCount: number, batchSize: number) => {

--- a/packages/freshmint/flow/index.ts
+++ b/packages/freshmint/flow/index.ts
@@ -39,7 +39,7 @@ export type CreateEditionResult = {
 
 export type EditionResult = {
   id: string;
-  limit: number;
+  limit: number | null;
   size: number;
 } | null;
 

--- a/packages/freshmint/mint/minters/EditionMinter.ts
+++ b/packages/freshmint/mint/minters/EditionMinter.ts
@@ -64,7 +64,6 @@ export class EditionMinter {
     csvOutputFile: string,
     withClaimKeys: boolean,
     batchSize: number,
-    templatesOnly: boolean,
     hooks: EditionHooks,
   ) {
     const entries = await readCSV(path.resolve(process.cwd(), csvInputFile));


### PR DESCRIPTION
Previously editions could only be fixed size, so the minting command would read a single `edition_size` field for each edition in the CSV file.

This PR adds support for an optional `edition_limit` field, which can be used to create editions with an undefined limit (i.e. open editions). Users can mint into open editions multiple times because there is no defined size limit.

If `edition_limit` field is omitted, then the CLI will set `edition_limit = edition_size`.